### PR TITLE
lookup team overrides stored in who-is-who

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,10 +14,10 @@
   version = "v6.10.0"
 
 [[projects]]
-  branch = "master"
+  branch = "pickabot-config"
   name = "github.com/Clever/who-is-who"
   packages = ["go-client"]
-  revision = "a1f8564796bcd47cc897cb032c94d079e203323e"
+  revision = "b89aab3e86121b49bf5ab2915815b5affba754e9"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -106,6 +106,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "02de3c56c7097befccbdb05bbc07f62dc3896b075af2c7f86951a306b76d25cb"
+  inputs-digest = "59d698c3b6d29035f42cf17ea141f6e7b03c1d5396352bea0ef28f39002b88de"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,7 +17,7 @@
   branch = "pickabot-config"
   name = "github.com/Clever/who-is-who"
   packages = ["go-client"]
-  revision = "b89aab3e86121b49bf5ab2915815b5affba754e9"
+  revision = "b359efdcd7350f855457c6951acf9641460af82e"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,10 +14,10 @@
   version = "v6.10.0"
 
 [[projects]]
-  branch = "pickabot-config"
+  branch = "master"
   name = "github.com/Clever/who-is-who"
   packages = ["go-client"]
-  revision = "b359efdcd7350f855457c6951acf9641460af82e"
+  revision = "07b861fb309acb3a22ca74923be05906dbed9aeb"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -58,8 +58,8 @@
 [[projects]]
   name = "github.com/stretchr/testify"
   packages = ["assert"]
-  revision = "b91bfb9ebec76498946beb6af7c0230c7cc7ba6c"
-  version = "v1.2.0"
+  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
+  version = "v1.2.1"
 
 [[projects]]
   branch = "master"
@@ -71,25 +71,25 @@
   branch = "master"
   name = "github.com/xeipuuv/gojsonpointer"
   packages = ["."]
-  revision = "6fe8760cad3569743d51ddbb243b26f8456742dc"
+  revision = "4e3ac2762d5f479393488629ee9370b50873b3a6"
 
 [[projects]]
   branch = "master"
   name = "github.com/xeipuuv/gojsonreference"
   packages = ["."]
-  revision = "e02fc20de94c78484cd5ffb007f8af96be030a45"
+  revision = "bd5ef7bd5415a7ac448318e64f11a24cd21e594b"
 
 [[projects]]
   branch = "master"
   name = "github.com/xeipuuv/gojsonschema"
   packages = ["."]
-  revision = "511d08a359d14c0dd9c4302af52ee9abb6f93c2a"
+  revision = "8bcffc811467a5f691810420385be6e66b35a317"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["websocket"]
-  revision = "5ccada7d0a7ba9aeb5d3aca8d3501b4c2a509fec"
+  revision = "f5dfe339be1d06f81b22525fe34671ee7d2c8904"
 
 [[projects]]
   name = "gopkg.in/Clever/kayvee-go.v6"
@@ -106,6 +106,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "59d698c3b6d29035f42cf17ea141f6e7b03c1d5396352bea0ef28f39002b88de"
+  inputs-digest = "8d07ece7a8b3f85cc51bdd4bda3bd8ae57af85289a30efcfd32affdfe69d5139"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,5 +31,4 @@
 
 [[override]]
   name = "github.com/Clever/who-is-who"
-  # TODO: Temporarily using branch with updated go-client
-  branch = "pickabot-config"
+  branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,3 +28,8 @@
 [[constraint]]
   name = "github.com/nlopes/slack"
   version = "0.1.0"
+
+[[override]]
+  name = "github.com/Clever/who-is-who"
+  # TODO: Temporarily using branch with updated go-client
+  branch = "pickabot-config"

--- a/bot.go
+++ b/bot.go
@@ -45,9 +45,9 @@ const pickUserProblem = "Sorry, I ran into an issue picking a user. Check my log
 
 // Override denotes a team override where as user should (not) be included on a team
 type Override struct {
-	User        whoswho.User
-	Team        string
-	AddOrRemove bool // true = added, false = removed
+	User    whoswho.User
+	Team    string
+	Include bool // true = added, false = removed
 }
 
 var teamOverridesLock = &sync.Mutex{}
@@ -190,9 +190,9 @@ func (bot *Bot) setTeamOverride(ev *slack.MessageEvent, userID, teamName string,
 	}
 
 	bot.TeamOverrides = append(bot.TeamOverrides, Override{
-		User:        whoswho.User{SlackID: userID},
-		Team:        actualTeamName,
-		AddOrRemove: addOrRemove,
+		User:    whoswho.User{SlackID: userID},
+		Team:    actualTeamName,
+		Include: addOrRemove,
 	})
 
 	if addOrRemove {
@@ -266,7 +266,7 @@ func (bot *Bot) buildTeam(teamName string) []whoswho.User {
 	for _, user := range teamMembers {
 		includeUser := true
 		for _, override := range bot.TeamOverrides {
-			if user.SlackID == override.User.SlackID && teamName == override.Team && !override.AddOrRemove {
+			if user.SlackID == override.User.SlackID && teamName == override.Team && !override.Include {
 				// user has been removed
 				includeUser = false
 				break
@@ -279,7 +279,7 @@ func (bot *Bot) buildTeam(teamName string) []whoswho.User {
 
 	// Add some members
 	for _, override := range bot.TeamOverrides {
-		if teamName == override.Team && override.AddOrRemove {
+		if teamName == override.Team && override.Include {
 			finalTeam = append(finalTeam, override.User)
 		}
 	}

--- a/bot_test.go
+++ b/bot_test.go
@@ -196,9 +196,9 @@ func TestAddOverride(t *testing.T) {
 	pickabot.DecodeMessage(makeSlackMessage("<@U1234> <@U5555> is an eng-example-team"))
 	assert.Equal(t, []Override{
 		Override{
-			User:        whoswho.User{SlackID: "U5555"},
-			Team:        "example-team",
-			AddOrRemove: true,
+			User:    whoswho.User{SlackID: "U5555"},
+			Team:    "example-team",
+			Include: true,
 		},
 	}, pickabot.TeamOverrides)
 
@@ -212,14 +212,14 @@ func TestAddOverride(t *testing.T) {
 	pickabot.DecodeMessage(makeSlackMessage("<@U1234> <@U7777> is not eng-example-team"))
 	assert.Equal(t, []Override{
 		Override{
-			User:        whoswho.User{SlackID: "U5555"},
-			Team:        "example-team",
-			AddOrRemove: true,
+			User:    whoswho.User{SlackID: "U5555"},
+			Team:    "example-team",
+			Include: true,
 		},
 		Override{
-			User:        whoswho.User{SlackID: "U7777"},
-			Team:        "example-team",
-			AddOrRemove: false,
+			User:    whoswho.User{SlackID: "U7777"},
+			Team:    "example-team",
+			Include: false,
 		},
 	}, pickabot.TeamOverrides)
 
@@ -233,14 +233,14 @@ func TestAddOverride(t *testing.T) {
 	pickabot.DecodeMessage(makeSlackMessage("<@U1234> <@U7777> is an eng-example-team"))
 	assert.Equal(t, []Override{
 		Override{
-			User:        whoswho.User{SlackID: "U5555"},
-			Team:        "example-team",
-			AddOrRemove: true,
+			User:    whoswho.User{SlackID: "U5555"},
+			Team:    "example-team",
+			Include: true,
 		},
 		Override{
-			User:        whoswho.User{SlackID: "U7777"},
-			Team:        "example-team",
-			AddOrRemove: true,
+			User:    whoswho.User{SlackID: "U7777"},
+			Team:    "example-team",
+			Include: true,
 		},
 	}, pickabot.TeamOverrides)
 
@@ -261,9 +261,9 @@ func TestAddOverrideAlternateMessageMatcher(t *testing.T) {
 	pickabot.DecodeMessage(makeSlackMessage("<@U1234> add <@U5555> to eng-example-team"))
 	assert.Equal(t, []Override{
 		Override{
-			User:        whoswho.User{SlackID: "U5555"},
-			Team:        "example-team",
-			AddOrRemove: true,
+			User:    whoswho.User{SlackID: "U5555"},
+			Team:    "example-team",
+			Include: true,
 		},
 	}, pickabot.TeamOverrides)
 
@@ -277,14 +277,14 @@ func TestAddOverrideAlternateMessageMatcher(t *testing.T) {
 	pickabot.DecodeMessage(makeSlackMessage("<@U1234> remove <@U7777> from eng-example-team"))
 	assert.Equal(t, []Override{
 		Override{
-			User:        whoswho.User{SlackID: "U5555"},
-			Team:        "example-team",
-			AddOrRemove: true,
+			User:    whoswho.User{SlackID: "U5555"},
+			Team:    "example-team",
+			Include: true,
 		},
 		Override{
-			User:        whoswho.User{SlackID: "U7777"},
-			Team:        "example-team",
-			AddOrRemove: false,
+			User:    whoswho.User{SlackID: "U7777"},
+			Team:    "example-team",
+			Include: false,
 		},
 	}, pickabot.TeamOverrides)
 
@@ -298,14 +298,14 @@ func TestAddOverrideAlternateMessageMatcher(t *testing.T) {
 	pickabot.DecodeMessage(makeSlackMessage("<@U1234> add <@U7777> to eng-example-team"))
 	assert.Equal(t, []Override{
 		Override{
-			User:        whoswho.User{SlackID: "U5555"},
-			Team:        "example-team",
-			AddOrRemove: true,
+			User:    whoswho.User{SlackID: "U5555"},
+			Team:    "example-team",
+			Include: true,
 		},
 		Override{
-			User:        whoswho.User{SlackID: "U7777"},
-			Team:        "example-team",
-			AddOrRemove: true,
+			User:    whoswho.User{SlackID: "U7777"},
+			Team:    "example-team",
+			Include: true,
 		},
 	}, pickabot.TeamOverrides)
 

--- a/main.go
+++ b/main.go
@@ -54,18 +54,9 @@ func main() {
 	slack.SetLogger(log.New(os.Stdout, "specbot: ", log.Lshortfile|log.LstdFlags))
 	api.SetDebug(false)
 
-	teams, err := buildTeams()
+	teams, overrides, err := buildTeams()
 	if err != nil {
 		log.Fatalf("error building teams: %s", err)
-	}
-
-	for teamName, users := range teams {
-		fmt.Printf("team=%s has members: ", teamName)
-		userText := []string{}
-		for _, u := range users {
-			userText = append(userText, fmt.Sprintf("%s %s (%s)", u.FirstName, u.LastName, u.SlackID))
-		}
-		fmt.Println(strings.Join(userText, ", "))
 	}
 
 	pickabot := &Bot{
@@ -73,27 +64,48 @@ func main() {
 		Logger:            logger.New("pickabot"),
 		Name:              os.Getenv("BOT_NAME"),
 		RandomSource:      rand.NewSource(time.Now().UnixNano()),
+		TeamOverrides:     overrides,
 		TeamToTeamMembers: teams,
+	}
+
+	for teamName := range teams {
+		fmt.Printf("team=%s has members: ", teamName)
+		users := pickabot.buildTeam(teamName)
+		userText := []string{}
+		for _, u := range users {
+			userText = append(userText, fmt.Sprintf("%s %s (%s)", u.FirstName, u.LastName, u.SlackID))
+		}
+		fmt.Println(strings.Join(userText, ", "))
 	}
 
 	SlackLoop(pickabot)
 }
 
-func buildTeams() (map[string][]whoswho.User, error) {
+func buildTeams() (map[string][]whoswho.User, []Override, error) {
 	endpoint, err := discovery.URL("who-is-who", "default")
 	if err != nil {
-		return nil, fmt.Errorf("discovery error: %s", err)
+		return nil, []Override{}, fmt.Errorf("discovery error: %s", err)
 	}
 
 	client := whoswho.NewClient(endpoint)
 	users, err := client.GetUserList()
 	if err != nil {
-		return nil, err
+		return nil, []Override{}, err
 	}
 
 	// fetch users from who-is-who
+	overrides := []Override{}
 	teams := map[string][]whoswho.User{}
 	for _, u := range users {
+		// Add overrides from who-is-who
+		for _, to := range u.Pickabot.TeamOverrides {
+			overrides = append(overrides, Override{
+				User:        u,
+				Team:        to.Team,
+				AddOrRemove: to.AddOrRemove == "add",
+			})
+		}
+
 		if !(strings.HasPrefix(u.Team, "Engineer") && u.Active) {
 			continue
 		}
@@ -107,5 +119,5 @@ func buildTeams() (map[string][]whoswho.User, error) {
 		teams[team] = append(teams[team], u)
 	}
 
-	return teams, nil
+	return teams, overrides, nil
 }

--- a/main.go
+++ b/main.go
@@ -100,9 +100,9 @@ func buildTeams() (map[string][]whoswho.User, []Override, error) {
 		// Add overrides from who-is-who
 		for _, to := range u.Pickabot.TeamOverrides {
 			overrides = append(overrides, Override{
-				User:        u,
-				Team:        to.Team,
-				AddOrRemove: to.AddOrRemove == "add",
+				User:    u,
+				Team:    to.Team,
+				Include: to.Include,
 			})
 		}
 


### PR DESCRIPTION
Store data like team overrides in who-is-who.

For now, look them up on pickabot boot.

TODO (future PR): When a new override is added in pickabot, persist it to who-is-who.