### PR TITLE
Fix auth expiration

### DIFF
--- a/github/auth.go
+++ b/github/auth.go
@@ -19,11 +19,13 @@ type Token struct {
 	Expiration time.Time `json:"expires_at,omitempty"`
 }
 
+var expirationTimeBufferDuration = 30 * time.Second
+
 // IsExpired returns whether the token is still valid
-// we give ourselves a 30 second buffer to give the subsequent requests to the Github API
+// we give ourselves a buffer to give the subsequent requests to the Github API
 // time to process
 func (t Token) IsExpired() bool {
-	return time.Now().Add(-1 * 30 * time.Second).After(t.Expiration)
+	return time.Now().Add(expirationTimeBufferDuration).After(t.Expiration)
 }
 
 func (a *AppClient) generateNewJWT() error {

--- a/github/auth_test.go
+++ b/github/auth_test.go
@@ -1,0 +1,41 @@
+package github
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTokenIsExpired(t *testing.T) {
+	tests := []struct {
+		name       string
+		expiration time.Time
+		want       bool
+	}{
+		{
+			name:       "future expiration",
+			expiration: time.Now().Add(2 * time.Hour),
+			want:       false,
+		},
+		{
+			name:       "past expiration",
+			expiration: time.Now().Add(-2 * time.Hour),
+			want:       true,
+		},
+		{
+			name:       "current expiration",
+			expiration: time.Now().Add(expirationTimeBufferDuration - time.Second),
+			want:       true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token := Token{
+				Expiration: tt.expiration,
+			}
+			got := token.IsExpired()
+			assert.Equal(t, tt.want, got, tt.name)
+		})
+	}
+}


### PR DESCRIPTION
The expiration logic was previously giving us a time window in the _opposite_ direction due to the sign flip I thought I removed 😓 

``` golang
time.Now().Add(-1 * 30 * time.Second).After(t.Expiration)
```
Fix the window and add test cases