### PR TITLE
Remove deprected Github API call

### DIFF
--- a/github/auth.go
+++ b/github/auth.go
@@ -74,7 +74,7 @@ func (a *AppClient) generateGithubAccessToken() error {
 
 	// ask for a token
 	client := &http.Client{}
-	req, err := http.NewRequest("POST", fmt.Sprintf("https://api.github.com/installations/%s/access_tokens", a.InstallationID), nil)
+	req, err := http.NewRequest("POST", fmt.Sprintf("https://api.github.com/app/installations/%s/access_tokens", a.InstallationID), nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
https://developer.github.com/changes/2020-04-15-replacing-create-installation-access-token-endpoint/ plus we got some emails about it.

This was just one of those things that's easier to fix than make a ticket for....

Testing: Did not test. If pickabot breaks, we can roll it back.