### PR TITLE
migrate to podOnly

### DIFF
--- a/launch/pickabot.yml
+++ b/launch/pickabot.yml
@@ -9,11 +9,17 @@ env:
 - GITHUB_PRIVATE_KEY
 - SLACK_ACCESS_TOKEN
 resources:
-  cpu: 0.0
-  max_mem: 1.1
+  cpu: 0.25
+  max_mem: 0.5
 shepherds:
 - "nathan.leiby@clever.com"
 expose: []
 dependencies:
 - who-is-who
-team: "eng-infra"
+team: eng-infra
+pod_config:
+  group: us-west-1
+  prod:
+    migrationState: podOnly
+  dev:
+     migrationState: podOnly


### PR DESCRIPTION
migrating pickabot directly to `podOnly` as it is low risk. Also running 2 instances will lead to same duplicated actions so lets delete homepod once this is verified to work