### PR TITLE
Upgrade to Go 1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/Clever/pickabot
     docker:
-      - image: circleci/golang:1.13-stretch
+      - image: circleci/golang:1.16-stretch
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SHELL := /bin/bash
 PKG := github.com/Clever/pickabot
 PKGS := $(shell go list ./... | grep -v /vendor | grep -v db | grep -v /mock | grep -v /slackapi | grep -v /tools)
 EXECUTABLE := $(shell basename $(PKG))
-$(eval $(call golang-version-check,1.13))
+$(eval $(call golang-version-check,1.16))
 
 all: test build
 
@@ -22,7 +22,7 @@ run: build
 
 install_deps:
 	go mod vendor
-	go build -o bin/mockgen ./vendor/github.com/golang/mock/mockgen
+	go build -mod=vendor -o bin/mockgen ./vendor/github.com/golang/mock/mockgen
 
 generate:
 	go generate ./


### PR DESCRIPTION
This PR migrates to Go 1.16.

If the build passes, no action is required by you, infra will merge and deploy this. For any questions, reach out to @taylor-sutton (Slack `taylor`) or #oncall-infra.
