### PR TITLE
Handle multi-word team names and override-only teams better.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Clever/eng-infra

--- a/bot_test.go
+++ b/bot_test.go
@@ -158,6 +158,29 @@ func TestPickTeamMember(t *testing.T) {
 	}
 }
 
+// Covers the case of a team appearing only as an override, not as an official team
+func TestPickOverrideTeam(t *testing.T) {
+	input := "<@U1234> pick an override-only-team"
+	t.Log("Input = ", input)
+	mockbot, mocks, mockCtrl := getMockBot(t)
+	mockbot.TeamOverrides = []Override{{
+		User: whoswho.User{
+			SlackID: "U5",
+		},
+		Team:    "override-only-team",
+		Include: true,
+	}}
+	defer mockCtrl.Finish()
+
+	mocks.SlackAPI.EXPECT().GetUserInfo("U1234").Return(makeSlackUser(testUserID), nil)
+	msg := "I choose you: <@U5>"
+	message := makeSlackOutgoingMessage(msg)
+	mocks.SlackRTM.EXPECT().NewOutgoingMessage(msg, testChannel).Return(message)
+	mocks.SlackRTM.EXPECT().SendMessage(message)
+
+	mockbot.DecodeMessage(makeSlackMessage(input))
+}
+
 func TestPickAssignTeamMember(t *testing.T) {
 	for _, input := range []string{
 		// Without "eng"

--- a/main.go
+++ b/main.go
@@ -158,7 +158,7 @@ func buildTeams(client whoIsWhoClientIface) (map[string][]whoswho.User, []Overri
 		split := strings.Split(u.Team, " - ")
 		team := split[1]
 		team = strings.ToLower(team)
-		team = strings.Replace(team, " ", "-", 1)
+		team = strings.ReplaceAll(team, " ", "-")
 
 		// Write user to teams
 		teams[team] = append(teams[team], u)


### PR DESCRIPTION
For some reason, pickabot suddenly stopped recognizing eng-data-dashboards and eng-sharing-apis. I'm not sure why; possibly the underlying data in who-is-who changed. At any rate, while debugging, I noticed:
1. These teams official names are Dashboard And Data Ingesting, and Sharing And APIs, which contain multiple spaces, but when converting them into the regex-friendly version, we only replace the first space, so they can't be referenced.
2. The names people had been using - eng-data-dashboards and eng-sharing-apis - were still in who-is-who, but only as overrides, not as main teams. But pickabot wasn't looking at teams in overrides when trying to match teams.

Changes:
- When converting from official team names to slack names, replace all spaces, not just the first.
  Pickabot does not allow spaces in team names (i.e. @pickabot pick eng-sharing and apis ... is
  invalid).
- When building the list of known teams, consider overrides as well as official teams.
  Sometimes a team might ONLY appear as an override, not as an official team. We still want to allow
  those to be found.
- Add a testcase for this.

My hope is that the overrides code will allow people to keep using the short names e.g. eng-data-dashboards, while the conversion change will allow the long names as a fallback (eng-dashboards-and-data-ingestion). In some ways what we want is team aliases, but that seemed more complicated than this to just get things working.