### PR TITLE
debug: List failed user when doing a query

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -536,7 +536,7 @@ func (bot *Bot) listTeamMembers(ev *slack.MessageEvent, teamName string) {
 	for _, t := range teamMembers {
 		info, err := bot.SlackAPIService.GetUserInfo(t.SlackID)
 		if err != nil {
-			bot.Logger.ErrorD("slack-api-error", logger.M{"error": err.Error(), "event-text": ev.Text})
+			bot.Logger.ErrorD("slack-api-error", logger.M{"error": err.Error(), "event-text": ev.Text, "failed-user": t.SlackID})
 			return
 		}
 


### PR DESCRIPTION
When running `@pickabot who is [team]`, Slack may fail to return any team members.

When debugging, Slack does not indicate the user it failed to look up.

This is important, because it means we can reconcile state if we simply remove that entry from who-is-who / some other location.