### PR TITLE
remove mesh_config

### DIFF
--- a/launch/pickabot.yml
+++ b/launch/pickabot.yml
@@ -26,8 +26,3 @@ deploy_config:
   canaryInProd: false
   autoDeployEnvs:
   - production
-mesh_config:
-  dev:
-    state: mesh_only
-  prod:
-    state: mesh_only


### PR DESCRIPTION
# JIRA
https://clever.atlassian.net/browse/INFRANG-6012

# Overview
Delete the mesh config as we are exiting mesh and this mesh_config is not used anymore.

# Testing
Currently catapult is using a feature flag in place of this mesh config and the feature flag is set to "alb_only" for this app. Which means this is already running in production

# Rollout
Merge PR and deploy via dapple
