### PR TITLE
[INFRANG-7090] Add config for golangci-lint

### DIFF
--- a/golangci.yml
+++ b/golangci.yml
@@ -1,0 +1,52 @@
+version: "2"
+
+linters:
+  exclusions:
+    # lax mode has a more loose definition of a generated file. Not all
+    # of Clever's code gen files adhere to the strict definition which
+    # is very specific.
+    generated: lax
+    paths:
+      # We dont label all of our generated files with comments.
+      - gen-go
+      - launch.go
+
+formatters:
+  enable:
+    - gofumpt
+    - gofmt
+    - goimports
+  exclusions:
+    # lax mode has a more loose definition of a generated file. Not all
+    # of Clever's code gen files adhere to the strict definition which
+    # is very specific.
+    generated: lax
+    paths:
+      # We dont label all of our generated files with comments.
+      - gen-go
+      - launch.go
+  settings:
+    gofmt:
+      # This is enabled by default in gofumpt. We are largely using this
+      # linter for the rewrite interface to any utility
+      simplify: false
+      rewrite-rules:
+        - pattern: 'interface{}'
+          replacement: 'any'
+    goimports:
+      # Group Clever packages into their own section.
+      local-prefixes:
+        - github.com/Clever
+
+issues:
+  # Only raise linter errors if the errors are on lines changed in the PR.
+  new: true
+  # A value of 0 disables the max visible issues so that we can see all of
+  # them at once
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+run:
+  # Read only means that go tool chain commands will fail if the go.mod requires changes.
+  modules-download-mode: readonly
+  allow-parallel-runners: true


### PR DESCRIPTION
# JIRA
https://clever.atlassian.net/browse/INFRANG-7090

# About
This PR adds configuration for [golangci-lint](https://golangci-lint.run/) that adhere to the new [Clever standards for Go](https://app.getguru.com/card/iX5KgazT/Go-Language-Standards). Note that this does not add CI enforcement of the standards. CI standard enforcement will be added to repos at a alter time. Please follow the steps in the standards guide to setup golangci-lint on your own machine.

# Testing
There is no testing needed here. This config file will only be used by developers on their local machine until CI configuration is added at a later time.
